### PR TITLE
Fix PHP Fatal error on sampledata:install routine

### DIFF
--- a/app/code/Magento/SampleData/Module/ConfigurableProduct/Setup/Product.php
+++ b/app/code/Magento/SampleData/Module/ConfigurableProduct/Setup/Product.php
@@ -80,9 +80,7 @@ class Product implements SetupInterface
             [
                 'entity' => 'catalog_product',
                 'behavior' => 'append',
-                'import_images_file_dir' => 'pub/media/catalog/product',
-                Import::FIELD_NAME_VALIDATION_STRATEGY =>
-                    ProcessingErrorAggregatorInterface::VALIDATION_STRATEGY_SKIP_ERRORS
+                'import_images_file_dir' => 'pub/media/catalog/product'
             ]
         );
 


### PR DESCRIPTION
The latest push to the magento2 develop branch breaks the sample data. Attempts to install fail due to referencing a now non-existant constant:

```
PHP Fatal error:  Undefined class constant 'FIELD_NAME_VALIDATION_STRATEGY' in /server/sites/m2.dev/var/tmp/m2-data/app/code/Magento/SampleData/Module/ConfigurableProduct/Setup/Product.php on line 84
PHP Stack trace:
PHP   1. {main}() /server/sites/m2.dev/bin/magento:0
PHP   2. Symfony\Component\Console\Application->run() /server/sites/m2.dev/bin/magento:25
PHP   3. Symfony\Component\Console\Application->doRun() /server/sites/m2.dev/vendor/symfony/console/Symfony/Component/Console/Application.php:126
PHP   4. Symfony\Component\Console\Application->doRunCommand() /server/sites/m2.dev/vendor/symfony/console/Symfony/Component/Console/Application.php:195
PHP   5. Symfony\Component\Console\Command\Command->run() /server/sites/m2.dev/vendor/symfony/console/Symfony/Component/Console/Application.php:874
PHP   6. Magento\SampleData\Console\Command\SampleDataInstallCommand->execute() /server/sites/m2.dev/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:257
PHP   7. Magento\SampleData\Model\SampleData->install() /server/sites/m2.dev/var/tmp/m2-data/app/code/Magento/SampleData/Console/Command/SampleDataInstallCommand.php:102
PHP   8. Magento\SampleData\Model\Installer->run() /server/sites/m2.dev/var/tmp/m2-data/app/code/Magento/SampleData/Model/SampleData.php:96
PHP   9. Magento\SampleData\Module\ConfigurableProduct\Setup->run() /server/sites/m2.dev/var/tmp/m2-data/app/code/Magento/SampleData/Model/Installer.php:113
PHP  10. Magento\SampleData\Module\ConfigurableProduct\Setup\Product->run() /server/sites/m2.dev/var/tmp/m2-data/app/code/Magento/SampleData/Module/ConfigurableProduct/Setup.php:34

Fatal error: Undefined class constant 'FIELD_NAME_VALIDATION_STRATEGY' in /server/sites/m2.dev/var/tmp/m2-data/app/code/Magento/SampleData/Module/ConfigurableProduct/Setup/Product.php on line 84

Call Stack:
    0.0002     229368   1. {main}() /server/sites/m2.dev/bin/magento:0
    2.9139   63247472   2. Symfony\Component\Console\Application->run() /server/sites/m2.dev/bin/magento:25
    2.9155   63292104   3. Symfony\Component\Console\Application->doRun() /server/sites/m2.dev/vendor/symfony/console/Symfony/Component/Console/Application.php:126
    2.9157   63293056   4. Symfony\Component\Console\Application->doRunCommand() /server/sites/m2.dev/vendor/symfony/console/Symfony/Component/Console/Application.php:195
    2.9157   63293536   5. Symfony\Component\Console\Command\Command->run() /server/sites/m2.dev/vendor/symfony/console/Symfony/Component/Console/Application.php:874
    2.9159   63297368   6. Magento\SampleData\Console\Command\SampleDataInstallCommand->execute() /server/sites/m2.dev/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:257
    2.9173   63325144   7. Magento\SampleData\Model\SampleData->install() /server/sites/m2.dev/var/tmp/m2-data/app/code/Magento/SampleData/Console/Command/SampleDataInstallCommand.php:102
    3.7413   70781968   8. Magento\SampleData\Model\Installer->run() /server/sites/m2.dev/var/tmp/m2-data/app/code/Magento/SampleData/Model/SampleData.php:96
   89.9485  146883664   9. Magento\SampleData\Module\ConfigurableProduct\Setup->run() /server/sites/m2.dev/var/tmp/m2-data/app/code/Magento/SampleData/Model/Installer.php:113
   89.9485  146884088  10. Magento\SampleData\Module\ConfigurableProduct\Setup\Product->run() /server/sites/m2.dev/var/tmp/m2-data/app/code/Magento/SampleData/Module/ConfigurableProduct/Setup.php:34

```

Note: I did not research alternatives to the removed argument. Based on the validation strategy used and the sample data installing with no errors, it may not be necessary any more.