### PR TITLE
fixing malformed classname

### DIFF
--- a/app/code/Magento/CustomerSampleData/etc/di.xml
+++ b/app/code/Magento/CustomerSampleData/etc/di.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <type name="\Magento\Framework\Mail\TransportInterface">
-        <plugin name="customer-sample-data-disable-registration-email-send" type="Magento\CustomerSampleData\Magento\Framework\Mail\Transport\MailPlugin"/>
-    </type>
+  <type name="Magento\Framework\Mail\TransportInterface">
+    <plugin name="customer-sample-data-disable-registration-email-send" type="Magento\CustomerSampleData\Magento\Framework\Mail\Transport\MailPlugin"/>
+  </type>
 </config>


### PR DESCRIPTION
\Magento\Framework\Mail\TransportInterface -> Magento\Framework\Mail\TransportInterface
made Magento crash since xsd phpClassName specifies 
`<xs:pattern value="([a-zA-Z_&#x7f;-&#xff;][a-zA-Z0-9_&#x7f;-&#xff;]*)(\\[a-zA-Z_&#x7f;-&#xff;][a-zA-Z0-9_&#x7f;-&#xff;]*)*"/>`