### PR TITLE
Change to auto create needed factory class

### DIFF
--- a/app/code/Magento/DownloadableSampleData/Model/Product.php
+++ b/app/code/Magento/DownloadableSampleData/Model/Product.php
@@ -49,6 +49,7 @@ class Product extends \Magento\CatalogSampleData\Model\Product
      * @param \Magento\CatalogSampleData\Model\Product\Gallery $gallery
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Eav\Model\Config $eavConfig
+     * @param \Magento\Downloadable\Api\Data\File\ContentInterfaceFactory $contentInterfaceFactory
      */
     public function __construct(
         SampleDataContext $sampleDataContext,
@@ -57,7 +58,8 @@ class Product extends \Magento\CatalogSampleData\Model\Product
         \Magento\DownloadableSampleData\Model\Product\Converter $converter,
         \Magento\CatalogSampleData\Model\Product\Gallery $gallery,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Eav\Model\Config $eavConfig
+        \Magento\Eav\Model\Config $eavConfig,
+        \Magento\Downloadable\Api\Data\File\ContentInterfaceFactory $contentInterfaceFactory
     ) {
         parent::__construct(
             $sampleDataContext,


### PR DESCRIPTION
The "generated" dir is not writeable on cloud, so Magento\Downloadable\Api\Data\File\ContentInterfaceFactory must be used in a constructor to be created during setup:di:compile. http://devdocs.magento.com/guides/v2.0/extension-dev-guide/code-generation.html#codegen-over-when Otherwise, when used [here](https://github.com/magento/magento2-sample-data/blob/c7a10675c62a5451d65a975f5ec357d773782619/app/code/Magento/DownloadableSampleData/Model/Product/Converter.php#L164), an exception will be thrown.

You can put the factory reference in any constructor. I just chose the most readily available one, since the Converter class did not have it's own.