### PR TITLE
Invalid module names

### DIFF
--- a/app/code/Magento/CmsSampleData/etc/module.xml
+++ b/app/code/Magento/CmsSampleData/etc/module.xml
@@ -13,7 +13,7 @@
             <module name="Magento_CatalogSampleData"/>
             <module name="Magento_BundleSampleData"/>
             <module name="Magento_ConfigurableSampleData"/>
-            <module name="Magento_GroupedSampleData"/>
+            <module name="Magento_GroupedProductSampleData"/>
             <module name="Magento_GiftCardSampleData"/>
             <module name="Magento_ThemeSampleData"/>
         </sequence>

--- a/app/code/Magento/ProductLinksSampleData/etc/module.xml
+++ b/app/code/Magento/ProductLinksSampleData/etc/module.xml
@@ -12,7 +12,7 @@
             <module name="Magento_CatalogSampleData"/>
             <module name="Magento_BundleSampleData"/>
             <module name="Magento_ConfigurableSampleData"/>
-            <module name="Magento_GroupedSampleData"/>
+            <module name="Magento_GroupedProductSampleData"/>
             <module name="Magento_GiftCardSampleData"/>
         </sequence>
     </module>

--- a/app/code/Magento/ReviewSampleData/etc/module.xml
+++ b/app/code/Magento/ReviewSampleData/etc/module.xml
@@ -13,7 +13,7 @@
             <module name="Magento_CatalogSampleData"/>
             <module name="Magento_BundleSampleData"/>
             <module name="Magento_ConfigurableSampleData"/>
-            <module name="Magento_GroupedSampleData"/>
+            <module name="Magento_GroupedProductSampleData"/>
             <module name="Magento_GiftCardSampleData"/>
         </sequence>
     </module>

--- a/app/code/Magento/SalesSampleData/etc/module.xml
+++ b/app/code/Magento/SalesSampleData/etc/module.xml
@@ -14,7 +14,7 @@
             <module name="Magento_CatalogSampleData"/>
             <module name="Magento_BundleSampleData"/>
             <module name="Magento_ConfigurableSampleData"/>
-            <module name="Magento_GroupedSampleData"/>
+            <module name="Magento_GroupedProductSampleData"/>
             <module name="Magento_GiftCardSampleData"/>
         </sequence>
     </module>

--- a/app/code/Magento/WishlistSampleData/etc/module.xml
+++ b/app/code/Magento/WishlistSampleData/etc/module.xml
@@ -14,7 +14,7 @@
             <module name="Magento_CatalogSampleData"/>
             <module name="Magento_BundleSampleData"/>
             <module name="Magento_ConfigurableSampleData"/>
-            <module name="Magento_GroupedSampleData"/>
+            <module name="Magento_GroupedProductSampleData"/>
             <module name="Magento_GiftCardSampleData"/>
         </sequence>
     </module>


### PR DESCRIPTION
There is no "Magento_GroupedSampleData". It should be "Magento_GroupedProductSampleData". 

Also when a listed sequence module is not found, an exception should be thrown, since [sequence declares the list of components that **must be** loaded](http://devdocs.magento.com/guides/v2.2/extension-dev-guide/build/module-load-order.html). An exception would alert the developer **SOMETHING IS WRONG AND NEEDS TO BE FIXED.**