### PR TITLE
MAGETWO-94218 Productlinks data

### DIFF
--- a/app/code/Magento/CmsSampleData/etc/module.xml
+++ b/app/code/Magento/CmsSampleData/etc/module.xml
@@ -13,7 +13,7 @@
             <module name="Magento_CatalogSampleData"/>
             <module name="Magento_BundleSampleData"/>
             <module name="Magento_ConfigurableSampleData"/>
-            <module name="Magento_GroupedSampleData"/>
+            <module name="Magento_GroupedProductSampleData"/>
             <module name="Magento_GiftCardSampleData"/>
             <module name="Magento_ThemeSampleData"/>
         </sequence>

--- a/app/code/Magento/ConfigurableSampleData/Setup/Installer.php
+++ b/app/code/Magento/ConfigurableSampleData/Setup/Installer.php
@@ -58,7 +58,7 @@ class Installer implements Setup\SampleData\InstallerInterface
         $this->productLinkSetup->install(
             ['Magento_ConfigurableSampleData::fixtures/Links/related.csv'],
             ['Magento_ConfigurableSampleData::fixtures/Links/upsell.csv'],
-            ['Magento_ConfigurableSampleData::fixtures/Links/crossell.csv']
+            ['Magento_ConfigurableSampleData::fixtures/Links/crosssell.csv']
         );
     }
 }

--- a/app/code/Magento/ConfigurableSampleData/etc/module.xml
+++ b/app/code/Magento/ConfigurableSampleData/etc/module.xml
@@ -13,6 +13,7 @@
             <module name="Magento_CatalogSampleData"/>
             <module name="Magento_DownloadableSampleData"/>
             <module name="Magento_BundleSampleData"/>
+            <module name="Magento_GroupedProductSampleData"/>
         </sequence>
     </module>
 </config>

--- a/app/code/Magento/ProductLinksSampleData/Model/ProductLink.php
+++ b/app/code/Magento/ProductLinksSampleData/Model/ProductLink.php
@@ -96,8 +96,7 @@ class ProductLink
                     $links = $this->productLinkRepository->getList($product);
                     $linkedProductSkus = explode("\n", $data['linked_sku']);
                     foreach ($linkedProductSkus as $linkedProductSku) {
-                        $linkedProduct = $this->productFactory->create();
-                        $linkedProductId = $linkedProduct->getIdBySku($linkedProductSku);
+                        $linkedProductId = $product->getIdBySku($linkedProductSku);
                         if (!$linkedProductId) {
                             continue;
                         }

--- a/app/code/Magento/ProductLinksSampleData/Model/ProductLink.php
+++ b/app/code/Magento/ProductLinksSampleData/Model/ProductLink.php
@@ -94,10 +94,14 @@ class ProductLink
                     $product->setId($productId);
                     $product->setSku($data['sku']);
                     $links = $this->productLinkRepository->getList($product);
-                    $linkedProductSkus = explode("\n", $data['linked_sku']);
-                    foreach ($linkedProductSkus as $linkedProductSku) {
+                    $linkedSkusByType = array_fill_keys(array_keys($linkTypes), []);
+                    foreach ($links as $link) {
+                        $linkedSkusByType[$link->getLinkType()][] = $link->getLinkedProductSku();
+                    }
+
+                    foreach (explode("\n", $data['linked_sku']) as $linkedProductSku) {
                         $linkedProductId = $product->getIdBySku($linkedProductSku);
-                        if (!$linkedProductId) {
+                        if (!$linkedProductId || in_array($linkedProductSku, $linkedSkusByType[$linkType])) {
                             continue;
                         }
 

--- a/app/code/Magento/ProductLinksSampleData/Setup/Installer.php
+++ b/app/code/Magento/ProductLinksSampleData/Setup/Installer.php
@@ -31,7 +31,7 @@ class Installer implements Setup\SampleData\InstallerInterface
         $this->productLink->install(
             ['Magento_ProductLinksSampleData::fixtures/related.csv'],
             ['Magento_ProductLinksSampleData::fixtures/upsell.csv'],
-            ['Magento_ProductLinksSampleData::fixtures/crossell.csv']
+            ['Magento_ProductLinksSampleData::fixtures/crosssell.csv']
         );
     }
 }

--- a/app/code/Magento/ProductLinksSampleData/etc/module.xml
+++ b/app/code/Magento/ProductLinksSampleData/etc/module.xml
@@ -12,7 +12,7 @@
             <module name="Magento_CatalogSampleData"/>
             <module name="Magento_BundleSampleData"/>
             <module name="Magento_ConfigurableSampleData"/>
-            <module name="Magento_GroupedSampleData"/>
+            <module name="Magento_GroupedProductSampleData"/>
             <module name="Magento_GiftCardSampleData"/>
         </sequence>
     </module>

--- a/app/code/Magento/ReviewSampleData/etc/module.xml
+++ b/app/code/Magento/ReviewSampleData/etc/module.xml
@@ -13,7 +13,7 @@
             <module name="Magento_CatalogSampleData"/>
             <module name="Magento_BundleSampleData"/>
             <module name="Magento_ConfigurableSampleData"/>
-            <module name="Magento_GroupedSampleData"/>
+            <module name="Magento_GroupedProductSampleData"/>
             <module name="Magento_GiftCardSampleData"/>
         </sequence>
     </module>

--- a/app/code/Magento/SalesSampleData/etc/module.xml
+++ b/app/code/Magento/SalesSampleData/etc/module.xml
@@ -14,7 +14,7 @@
             <module name="Magento_CatalogSampleData"/>
             <module name="Magento_BundleSampleData"/>
             <module name="Magento_ConfigurableSampleData"/>
-            <module name="Magento_GroupedSampleData"/>
+            <module name="Magento_GroupedProductSampleData"/>
             <module name="Magento_GiftCardSampleData"/>
         </sequence>
     </module>

--- a/app/code/Magento/WishlistSampleData/etc/module.xml
+++ b/app/code/Magento/WishlistSampleData/etc/module.xml
@@ -14,7 +14,7 @@
             <module name="Magento_CatalogSampleData"/>
             <module name="Magento_BundleSampleData"/>
             <module name="Magento_ConfigurableSampleData"/>
-            <module name="Magento_GroupedSampleData"/>
+            <module name="Magento_GroupedProductSampleData"/>
             <module name="Magento_GiftCardSampleData"/>
         </sequence>
     </module>


### PR DESCRIPTION
## Scope
### Bug
* [MAGETWO-94218](https://jira.corp.magento.com/browse/MAGETWO-94218) Data from module ProductLinksSampleData is not installed

### Bamboo CI Builds
* [x] [M2, CI (CE + EE) - 2.3-develop - L4](https://bamboo.corp.magento.com/browse/MCCE23-L41284/latest)
* [x] [M2, CI (CE + EE) - 2.3-develop - PAT](https://bamboo.corp.magento.com/browse/MCCE23-PAT1146/latest)

### Related Pull Requests
https://github.com/magento/magento2ce/pull/3111
https://github.com/magento/magento2ee/pull/1187

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
