### PR TITLE
MAGETWO-89802: Sample Data Attributes are incorrectly displayed on se…

### DIFF
--- a/app/code/Magento/ConfigurableSampleData/fixtures/categories.csv
+++ b/app/code/Magento/ConfigurableSampleData/fixtures/categories.csv
@@ -1,5 +1,5 @@
 name,url_key,path,active,is_anchor,include_in_menu,position,display_mode,custom_layout_update
-Men,men,,1,0,1,3,PAGE,"<referenceContainer name=""catalog.leftnav"" remove=""true""/>"
+Men,men,,1,1,1,3,PAGE,"<referenceContainer name=""catalog.leftnav"" remove=""true""/>"
 Tops,tops-men,Men,1,1,1,,,
 Bottoms,bottoms-men,Men,1,1,1,,,
 Jackets,jackets-men,Men/Tops,1,1,1,,,
@@ -8,7 +8,7 @@ Tees,tees-men,Men/Tops,1,1,1,,,
 Tanks,tanks-men,Men/Tops,1,1,1,,,
 Pants,pants-men,Men/Bottoms,1,1,1,,,
 Shorts,shorts-men,Men/Bottoms,1,1,1,,,
-Women,women,,1,0,1,2,PAGE,"<referenceContainer name=""catalog.leftnav"" remove=""true""/>"
+Women,women,,1,1,1,2,PAGE,"<referenceContainer name=""catalog.leftnav"" remove=""true""/>"
 Tops,tops-women,Women,1,1,1,,,
 Bottoms,bottoms-women,Women,1,1,1,,,
 Jackets,jackets-women,Women/Tops,1,1,1,,,


### PR DESCRIPTION
## Scope
### Bug
* [MAGETWO-89802](https://jira.corp.magento.com/browse/MAGETWO-89802) Sample Data Attributes are incorrectly displayed on search layered navigation

### Bamboo CI Builds

### Related Pull Requests
