### PR TITLE
sync 2.3.0 release with qwerty

### DIFF
--- a/app/code/Magento/SalesSampleData/etc/module.xml
+++ b/app/code/Magento/SalesSampleData/etc/module.xml
@@ -16,6 +16,7 @@
             <module name="Magento_ConfigurableSampleData"/>
             <module name="Magento_GroupedProductSampleData"/>
             <module name="Magento_GiftCardSampleData"/>
+            <module name="Magento_TaxSampleData"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
## Scope
### Bug
* [MAGETWO-89328](https://jira.corp.magento.com/browse/MAGETWO-89328) Temporal coupling between CatalogSearch and CatalogRule 

### Bamboo CI Builds
* [X] [M2, CI (CE + EE) - 2.3-develop - L4](https://bamboo.corp.magento.com/browse/MCCE23-L41683/latest)
* [x] [M2, CI (CE + EE) - 2.3-develop - Performance Acceptance Test](https://bamboo.corp.magento.com/browse/MCCE23-PAT1517/latest)

### Related Pull Requests
https://github.com/magento/magento2ce/pull/3409
https://github.com/magento/magento2ee/pull/1329
https://github.com/magento/magento2-infrastructure/pull/685

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
