### PR TITLE
MAGETWO-95186: [2.3] Incorrect table rates shipping charge at check out with cart price rule

### DIFF
--- a/app/code/Magento/OfflineShippingSampleData/Model/Tablerate.php
+++ b/app/code/Magento/OfflineShippingSampleData/Model/Tablerate.php
@@ -8,6 +8,7 @@ namespace Magento\OfflineShippingSampleData\Model;
 use Magento\Framework\Setup\SampleData\Context as SampleDataContext;
 use Magento\Framework\App\ObjectManager;
 use Magento\Config\App\Config\Type\System as SystemConfig;
+use Magento\OfflineShipping\Model\Carrier\Tablerate as CarrierTablerate;
 
 /**
  * Class Tablerate
@@ -128,7 +129,7 @@ class Tablerate
                             'dest_country_id' => $data['country'],
                             'dest_region_id' => $regionId,
                             'dest_zip' => $data['zip'],
-                            'condition_name' => 'package_value',
+                            'condition_name' => CarrierTablerate::CONDITION_CODE_PACKAGE_VALUE_WITH_DISCOUNT,
                             'condition_value' => $data['order_subtotal'],
                             'price' => $data['price'],
                             'cost' => 0,
@@ -146,7 +147,9 @@ class Tablerate
         }
 
         $this->configWriter->save('carriers/tablerate/active', 1);
-        $this->configWriter->save('carriers/tablerate/condition_name', 'package_value');
+        $this->configWriter->save(
+            'carriers/tablerate/condition_name', CarrierTablerate::CONDITION_CODE_PACKAGE_VALUE_WITH_DISCOUNT
+        );
         $this->cacheTypeList->cleanType('config');
         $this->systemConfig->clean();
     }

--- a/app/code/Magento/OfflineShippingSampleData/Model/Tablerate.php
+++ b/app/code/Magento/OfflineShippingSampleData/Model/Tablerate.php
@@ -129,7 +129,7 @@ class Tablerate
                             'dest_country_id' => $data['country'],
                             'dest_region_id' => $regionId,
                             'dest_zip' => $data['zip'],
-                            'condition_name' => CarrierTablerate::CONDITION_CODE_PACKAGE_VALUE_WITH_DISCOUNT,
+                            'condition_name' => 'package_value_with_discount',
                             'condition_value' => $data['order_subtotal'],
                             'price' => $data['price'],
                             'cost' => 0,
@@ -148,7 +148,7 @@ class Tablerate
 
         $this->configWriter->save('carriers/tablerate/active', 1);
         $this->configWriter->save(
-            'carriers/tablerate/condition_name', CarrierTablerate::CONDITION_CODE_PACKAGE_VALUE_WITH_DISCOUNT
+            'carriers/tablerate/condition_name', 'package_value_with_discount'
         );
         $this->cacheTypeList->cleanType('config');
         $this->systemConfig->clean();


### PR DESCRIPTION
## Scope
### Bug
* [MAGETWO-95186](https://jira.corp.magento.com/browse/MAGETWO-95186) [2.3] Incorrect table rates shipping charge at check out with cart price rule

### Bamboo CI Builds
* [ ] [M2, CI (CE + EE) - 2.3-develop - Performance Acceptance Test](https://bamboo.corp.magento.com/browse/MCCE23-PAT2143/latest)

### Related Pull Requests
Delivered in BUNCH:
https://github.com/magento/magento2ce/pull/3725
https://github.com/magento/magento2ee/pull/1491
https://github.com/magento/magento2b2b/pull/631
https://github.com/magento/magento2-infrastructure/pull/751

Individual PR 38:
https://github.com/magento/magento2ce/pull/3697
https://github.com/magento/magento2ee/pull/1477
https://github.com/magento/magento2b2b/pull/628
https://github.com/magento/magento2-infrastructure/pull/739

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green