### PR TITLE
[Trigger] MC-15519: DB Compare Tool uses entity_id instead of row_id

### DIFF
--- a/app/code/Magento/MsrpSampleData/etc/module.xml
+++ b/app/code/Magento/MsrpSampleData/etc/module.xml
@@ -10,6 +10,7 @@
         <sequence>
             <module name="Magento_Msrp"/>
             <module name="Magento_SampleData"/>
+            <module name="Magento_ConfigurableSampleData"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
## Scope
### Bug
* [MC-15519](https://jira.corp.magento.com/browse/MC-15519) DB Compare Tool uses entity_id instead of row_id

### Bamboo CI Builds
### Related Pull Requests
https://github.com/magento/magento2-infrastructure/pull/855
### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
