### PR TITLE
MC-18994: Revert PHP 7.0 removal from 2.2.10

### DIFF
--- a/app/code/Magento/BundleSampleData/composer.json
+++ b/app/code/Magento/BundleSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-bundle-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-bundle": "100.2.*",
         "magento/module-sample-data": "100.2.*",
         "magento/module-catalog-sample-data": "100.2.*",

--- a/app/code/Magento/CatalogRuleSampleData/composer.json
+++ b/app/code/Magento/CatalogRuleSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-catalog-rule-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-catalog-rule": "101.0.*",
         "magento/module-sample-data": "100.2.*",
         "magento/module-store": "100.2.*",

--- a/app/code/Magento/CatalogSampleData/composer.json
+++ b/app/code/Magento/CatalogSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-catalog-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-sample-data": "100.2.*",
         "magento/module-store": "100.2.*",
         "magento/module-eav": "101.0.*",

--- a/app/code/Magento/CmsSampleData/composer.json
+++ b/app/code/Magento/CmsSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-cms-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-cms": "102.0.*",
         "magento/module-sample-data": "100.2.*",
         "magento/module-theme-sample-data": "100.2.*",

--- a/app/code/Magento/ConfigurableSampleData/composer.json
+++ b/app/code/Magento/ConfigurableSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-configurable-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-configurable-product": "100.2.*",
         "magento/module-sample-data": "100.2.*",
         "magento/module-product-links-sample-data": "100.2.*",

--- a/app/code/Magento/CustomerSampleData/composer.json
+++ b/app/code/Magento/CustomerSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-customer-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-sample-data": "100.2.*",
         "magento/module-customer": "101.0.*",
         "magento/module-directory": "100.2.*",

--- a/app/code/Magento/DownloadableSampleData/composer.json
+++ b/app/code/Magento/DownloadableSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-downloadable-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-sample-data": "100.2.*",
         "magento/module-catalog-sample-data": "100.2.*",
         "magento/module-downloadable": "100.2.*",

--- a/app/code/Magento/GroupedProductSampleData/composer.json
+++ b/app/code/Magento/GroupedProductSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-grouped-product-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-sample-data": "100.2.*",
         "magento/module-catalog-sample-data": "100.2.*",
         "magento/module-grouped-product": "100.2.*",

--- a/app/code/Magento/MsrpSampleData/composer.json
+++ b/app/code/Magento/MsrpSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-msrp-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-sample-data": "100.2.*",
         "magento/module-msrp": "100.2.*",
         "magento/module-customer": "101.0.*",

--- a/app/code/Magento/OfflineShippingSampleData/composer.json
+++ b/app/code/Magento/OfflineShippingSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-offline-shipping-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-sample-data": "100.2.*",
         "magento/module-offline-shipping": "100.2.*",
         "magento/module-directory": "100.2.*",

--- a/app/code/Magento/ProductLinksSampleData/composer.json
+++ b/app/code/Magento/ProductLinksSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-product-links-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-catalog-sample-data": "100.2.*",
         "magento/module-sample-data": "100.2.*",
         "magento/module-catalog": "102.0.*"

--- a/app/code/Magento/ReviewSampleData/composer.json
+++ b/app/code/Magento/ReviewSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-review-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-sample-data": "100.2.*",
         "magento/module-review": "100.2.*",
         "magento/module-customer": "101.0.*",

--- a/app/code/Magento/SalesRuleSampleData/composer.json
+++ b/app/code/Magento/SalesRuleSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-sales-rule-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-sample-data": "100.2.*",
         "magento/module-catalog-rule-sample-data": "100.2.*",
         "magento/module-sales-rule": "101.0.*",

--- a/app/code/Magento/SalesSampleData/composer.json
+++ b/app/code/Magento/SalesSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-sales-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-sales": "101.0.*",
         "magento/module-sample-data": "100.2.*",
         "magento/module-configurable-sample-data": "100.2.*",

--- a/app/code/Magento/SwatchesSampleData/composer.json
+++ b/app/code/Magento/SwatchesSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-swatches-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-swatches": "100.2.*",
         "magento/module-sample-data": "100.2.*",
         "magento/module-eav": "101.0.*",

--- a/app/code/Magento/TaxSampleData/composer.json
+++ b/app/code/Magento/TaxSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-tax-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-tax": "100.2.*",
         "magento/module-sample-data": "100.2.*",
         "magento/module-directory": "100.2.*"

--- a/app/code/Magento/ThemeSampleData/composer.json
+++ b/app/code/Magento/ThemeSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-theme-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-theme": "100.2.*",
         "magento/module-sample-data": "100.2.*",
         "magento/module-store": "100.2.*"

--- a/app/code/Magento/WidgetSampleData/composer.json
+++ b/app/code/Magento/WidgetSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-widget-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-widget": "101.0.*",
         "magento/module-sample-data": "100.2.*",
         "magento/module-theme": "100.2.*",

--- a/app/code/Magento/WishlistSampleData/composer.json
+++ b/app/code/Magento/WishlistSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-wishlist-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
         "magento/module-wishlist": "101.0.*",
         "magento/module-sample-data": "100.2.*",
         "magento/module-customer": "101.0.*",


### PR DESCRIPTION
### Related Pull Requests
https://github.com/magento/magento2ce/pull/4608
https://github.com/magento/magento2ee/pull/1890
https://github.com/magento/magento2b2b/pull/798
https://github.com/magento/magento2-infrastructure/pull/911
https://github.com/magento/magento2-sample-data-ee/pull/44