### PR TITLE
Updated PHP versions in composer files

### DIFF
--- a/app/code/Magento/BundleSampleData/composer.json
+++ b/app/code/Magento/BundleSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-bundle-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-bundle": "*",
         "magento/module-catalog-sample-data": "*",

--- a/app/code/Magento/CatalogRuleSampleData/composer.json
+++ b/app/code/Magento/CatalogRuleSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-catalog-rule-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-catalog-rule": "*",
         "magento/module-store": "*",

--- a/app/code/Magento/CatalogSampleData/composer.json
+++ b/app/code/Magento/CatalogSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-catalog-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-store": "*",
         "magento/module-eav": "*",

--- a/app/code/Magento/CmsSampleData/composer.json
+++ b/app/code/Magento/CmsSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-cms-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-cms": "*",
         "magento/module-theme-sample-data": "*",

--- a/app/code/Magento/ConfigurableSampleData/composer.json
+++ b/app/code/Magento/ConfigurableSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-configurable-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-configurable-product": "*",
         "magento/module-product-links-sample-data": "*",

--- a/app/code/Magento/CustomerSampleData/composer.json
+++ b/app/code/Magento/CustomerSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-customer-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-customer": "*",
         "magento/module-directory": "*",

--- a/app/code/Magento/DownloadableSampleData/composer.json
+++ b/app/code/Magento/DownloadableSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-downloadable-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-catalog-sample-data": "*",
         "magento/module-downloadable": "*",

--- a/app/code/Magento/GroupedProductSampleData/composer.json
+++ b/app/code/Magento/GroupedProductSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-grouped-product-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-catalog-sample-data": "*",
         "magento/module-grouped-product": "*",

--- a/app/code/Magento/MsrpSampleData/composer.json
+++ b/app/code/Magento/MsrpSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-msrp-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-msrp": "*",
         "magento/module-customer": "*",

--- a/app/code/Magento/OfflineShippingSampleData/composer.json
+++ b/app/code/Magento/OfflineShippingSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-offline-shipping-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-offline-shipping": "*",
         "magento/module-directory": "*",

--- a/app/code/Magento/ProductLinksSampleData/composer.json
+++ b/app/code/Magento/ProductLinksSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-product-links-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-catalog": "*"
     },

--- a/app/code/Magento/ReviewSampleData/composer.json
+++ b/app/code/Magento/ReviewSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-review-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-review": "*",
         "magento/module-customer": "*",

--- a/app/code/Magento/SalesRuleSampleData/composer.json
+++ b/app/code/Magento/SalesRuleSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-sales-rule-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-catalog-rule-sample-data": "*",
         "magento/module-sales-rule": "*",

--- a/app/code/Magento/SalesSampleData/composer.json
+++ b/app/code/Magento/SalesSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-sales-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-sales": "*",
         "magento/module-configurable-sample-data": "*",

--- a/app/code/Magento/SwatchesSampleData/composer.json
+++ b/app/code/Magento/SwatchesSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-swatches-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-eav": "*",
         "magento/module-catalog": "*"

--- a/app/code/Magento/TaxSampleData/composer.json
+++ b/app/code/Magento/TaxSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-tax-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-tax": "*",
         "magento/module-directory": "*"

--- a/app/code/Magento/ThemeSampleData/composer.json
+++ b/app/code/Magento/ThemeSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-theme-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-theme": "*",
         "magento/module-store": "*"

--- a/app/code/Magento/WidgetSampleData/composer.json
+++ b/app/code/Magento/WidgetSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-widget-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-widget": "*",
         "magento/module-theme": "*",

--- a/app/code/Magento/WishlistSampleData/composer.json
+++ b/app/code/Magento/WishlistSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-wishlist-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.3.0||~7.4.0",
+        "php": "~7.4.0||~8.0.0",
         "magento/framework": "*",
         "magento/module-wishlist": "*",
         "magento/module-customer": "*",


### PR DESCRIPTION
### Description (*)
This pull request provides the update of the PHP version in require section to "~7.4.0||~8.0.0||~8.1.0" into all composer files.
Builds of this PR should run with PHP 7.4 environment.

### Related Pull Requests
https://github.com/magento/magento2/pull/33997
https://github.com/magento/partners-magento2ee/pull/602
https://github.com/magento/partners-magento2b2b/pull/587
https://github.com/magento/inventory/pull/3323
https://github.com/magento/adobe-stock-integration/pull/1867
https://github.com/magento/security-package/pull/305
https://github.com/magento/magento2-page-builder/pull/774
https://github.com/magento/magento2-page-builder-ee/pull/191
https://github.com/magento/adobe-ims/pull/11
<!-- related pull request placeholder -->

### Related Issues (*)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#34009
