### PR TITLE
Changed restrictions for php to "~7.4.0||~8.1.0" into `composer.json` files

### DIFF
--- a/app/code/Magento/BundleSampleData/composer.json
+++ b/app/code/Magento/BundleSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-bundle-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-bundle": "*",
         "magento/module-catalog-sample-data": "*",

--- a/app/code/Magento/CatalogRuleSampleData/composer.json
+++ b/app/code/Magento/CatalogRuleSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-catalog-rule-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog-rule": "*",
         "magento/module-store": "*",

--- a/app/code/Magento/CatalogSampleData/composer.json
+++ b/app/code/Magento/CatalogSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-catalog-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-store": "*",
         "magento/module-eav": "*",

--- a/app/code/Magento/CmsSampleData/composer.json
+++ b/app/code/Magento/CmsSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-cms-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-cms": "*",
         "magento/module-theme-sample-data": "*",

--- a/app/code/Magento/ConfigurableSampleData/composer.json
+++ b/app/code/Magento/ConfigurableSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-configurable-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-configurable-product": "*",
         "magento/module-product-links-sample-data": "*",

--- a/app/code/Magento/CustomerSampleData/composer.json
+++ b/app/code/Magento/CustomerSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-customer-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-customer": "*",
         "magento/module-directory": "*",

--- a/app/code/Magento/DownloadableSampleData/composer.json
+++ b/app/code/Magento/DownloadableSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-downloadable-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog-sample-data": "*",
         "magento/module-downloadable": "*",

--- a/app/code/Magento/GroupedProductSampleData/composer.json
+++ b/app/code/Magento/GroupedProductSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-grouped-product-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog-sample-data": "*",
         "magento/module-grouped-product": "*",

--- a/app/code/Magento/MsrpSampleData/composer.json
+++ b/app/code/Magento/MsrpSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-msrp-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-msrp": "*",
         "magento/module-customer": "*",

--- a/app/code/Magento/OfflineShippingSampleData/composer.json
+++ b/app/code/Magento/OfflineShippingSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-offline-shipping-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-offline-shipping": "*",
         "magento/module-directory": "*",

--- a/app/code/Magento/ProductLinksSampleData/composer.json
+++ b/app/code/Magento/ProductLinksSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-product-links-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*"
     },

--- a/app/code/Magento/ReviewSampleData/composer.json
+++ b/app/code/Magento/ReviewSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-review-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-review": "*",
         "magento/module-customer": "*",

--- a/app/code/Magento/SalesRuleSampleData/composer.json
+++ b/app/code/Magento/SalesRuleSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-sales-rule-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog-rule-sample-data": "*",
         "magento/module-sales-rule": "*",

--- a/app/code/Magento/SalesSampleData/composer.json
+++ b/app/code/Magento/SalesSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-sales-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-sales": "*",
         "magento/module-configurable-sample-data": "*",

--- a/app/code/Magento/SwatchesSampleData/composer.json
+++ b/app/code/Magento/SwatchesSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-swatches-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-eav": "*",
         "magento/module-catalog": "*"

--- a/app/code/Magento/TaxSampleData/composer.json
+++ b/app/code/Magento/TaxSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-tax-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-tax": "*",
         "magento/module-directory": "*"

--- a/app/code/Magento/ThemeSampleData/composer.json
+++ b/app/code/Magento/ThemeSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-theme-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-theme": "*",
         "magento/module-store": "*"

--- a/app/code/Magento/WidgetSampleData/composer.json
+++ b/app/code/Magento/WidgetSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-widget-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-widget": "*",
         "magento/module-theme": "*",

--- a/app/code/Magento/WishlistSampleData/composer.json
+++ b/app/code/Magento/WishlistSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-wishlist-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-wishlist": "*",
         "magento/module-customer": "*",


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This pull request (PR) provides fixes for `composer.json` files

1. remove restriction `"~8.0.0"` for `"php"` requirements

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/partners-magento2b2b#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#34852

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
